### PR TITLE
Fix struct encoding regression

### DIFF
--- a/lib/ink/encoder.ex
+++ b/lib/ink/encoder.ex
@@ -10,6 +10,12 @@ defmodule Ink.Encoder do
               is_tuple(value) or is_function(value),
        do: inspect(value)
 
+  defp encode_value(%{__struct__: _} = value) do
+    value
+    |> Map.from_struct
+    |> encode_value
+  end
+
   defp encode_value(value) when is_map(value) do
     Enum.into(value, %{}, fn {k, v} ->
       {encode_value(k), encode_value(v)}

--- a/test/ink/encoder_test.exs
+++ b/test/ink/encoder_test.exs
@@ -1,6 +1,10 @@
 defmodule Ink.EncoderTest do
   use ExUnit.Case, async: true
 
+  defmodule TestStruct do
+    defstruct [:field]
+  end
+
   test "it can encode PIDs" do
     assert {:ok, ~s({"pid":"#PID<0.250.0>"})} ==
              Ink.Encoder.encode(%{pid: :c.pid(0, 250, 0)})
@@ -33,6 +37,11 @@ defmodule Ink.EncoderTest do
   test "it recursively encodes maps" do
     assert {:ok, ~s({"stuff":{"pid":"#PID<0.250.0>"}})} ==
              Ink.Encoder.encode(%{stuff: %{pid: :c.pid(0, 250, 0)}})
+  end
+
+  test "it recursively encodes struct" do
+    assert {:ok, ~s({"field":{"pid":"#PID<0.250.0>"}})} ==
+             Ink.Encoder.encode(%TestStruct{field: %{pid: :c.pid(0, 250, 0)}})
   end
 
   test "it encodes map keys" do


### PR DESCRIPTION
This is a regression between 0.7.4 and 0.8.0. Poison can encode `struct`, the new `Ink.Encode` raise an error as `struct`s are not Enumerable.