### PR TITLE
Replace Mix.env() with config whether to log the encoding error

### DIFF
--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -28,8 +28,8 @@ defmodule Ink do
   all)
   - `:exclude_hostname` exclude local `hostname` from the log (default:
   false)
-  - `:log_encoding_error` whether to log the encoding error, the error will not be
-  JSON-formatted (default: true)
+  - `:log_encoding_error` whether to log errors that happen during JSON encoding
+  (default: true)
 
   ### Filtering secrets
 

--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -26,8 +26,10 @@ defmodule Ink do
   (default: `[]`)
   - `:metadata` the metadata keys that should be included in the logs (default:
   all)
-   - `:exclude_hostname` exclude local `hostname` from the log (default:
+  - `:exclude_hostname` exclude local `hostname` from the log (default:
   false)
+  - `:log_encoding_error` whether to log the encoding error, the error will not be
+  JSON-formatted (default: true)
 
   ### Filtering secrets
 
@@ -155,7 +157,10 @@ defmodule Ink do
   end
 
   defp log_json(other, config) do
-    if Mix.env() == :dev, do: log_to_device(inspect(other), config.io_device)
+    case config.log_encoding_error do
+      true -> log_to_device(inspect(other), config.io_device)
+      _ -> :ok
+    end
   end
 
   defp log_to_device(msg, io_device), do: IO.puts(io_device, msg)


### PR DESCRIPTION
Since neither [distillery](https://hexdocs.pm/distillery/) nor the official release feature [introduced in Elixir 1.9](https://elixir-lang.org/blog/2019/06/24/elixir-v1-9-0-released/) includes `Mix` toolings, Ink will throw error on a specific edge case where the log message cannot be JSON-encoded as it attempts to call `Mix.env()` but the module is not available.

This PR fixes the issue by replacing the environment detection with a config value `:log_encoding_error`.

Ref: https://github.com/omisego/elixir-omg/issues/1477