### PR TITLE
Add default value for :log_encoding_error option

### DIFF
--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -230,7 +230,9 @@ defmodule Ink do
       filtered_uri_credentials: [],
       secret_strings: [],
       io_device: :stdio,
-      metadata: nil
+      metadata: nil,
+      exclude_hostname: false,
+      log_encoding_error: true
     }
   end
 

--- a/test/ink_test.exs
+++ b/test/ink_test.exs
@@ -152,4 +152,10 @@ defmodule InkTest do
 
     refute_receive {:io_request, _, _, {:put_chars, :unicode, _msg}}
   end
+
+  test "defaults the behavior to log_encoding_error: true" do
+    Logger.info("\xFF")
+
+    assert_receive {:io_request, _, _, {:put_chars, :unicode, _msg}}
+  end
 end


### PR DESCRIPTION
With introduction of `:log_encoding_error` in #57, the default value was not configured and so the logger would [crash](https://github.com/omisego/elixir-omg/issues/1511) when the option is not explicitly configured.

This PR introduces that default option along with the also missing `:exclude_hostname` default value.