### PR TITLE
Log full content on error

### DIFF
--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -169,10 +169,16 @@ defmodule Ink do
     |> log_to_device(config.io_device)
   end
 
-  defp log_json(other, config) do
+  defp log_json(error, config) do
     case config.log_encoding_error do
-      true -> log_to_device(inspect(other, limit: :infinity), config.io_device)
-      _ -> :ok
+      true ->
+        error
+        |> inspect(limit: :infinity)
+        |> filter_secret_strings(config.secret_strings)
+        |> log_to_device(config)
+
+      _ ->
+        :ok
     end
   end
 

--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -150,9 +150,6 @@ defmodule Ink do
     end)
   end
 
-  # Attempts to encode the log content. On error, the original log content
-  # is appended to the return, so subsequent callers can operate on both
-  # the error and the full log content.
   defp encode_map(log) do
     case Ink.Encoder.encode(log) do
       {:ok, _} = result ->

--- a/test/ink_test.exs
+++ b/test/ink_test.exs
@@ -143,7 +143,10 @@ defmodule InkTest do
     Logger.info("\xFF")
 
     assert_receive {:io_request, _, _, {:put_chars, :unicode, msg}}
-    assert msg =~ "{:error, %Jason.EncodeError{message: \"invalid byte 0xFF in <<255>>\"}}"
+    assert msg =~ "{:error, %Jason.EncodeError{message: \"invalid byte 0xFF in <<255>>\"},"
+    assert msg =~ "name:"
+    assert msg =~ "msg:"
+    assert msg =~ "level:"
   end
 
   test "respects log_encoding_error: false" do


### PR DESCRIPTION
On encoding error e.g. attempting to log non-printable binaries, the error log is logged in plain text like below:

```text
{:error, %Jason.EncodeError{message: "invalid byte 0xB8 in <<216, 169, 57, 189,
158, 59, 180, 137, 49, 59, 243, 199, 20, 151, 234, 12, 179, 172, 91, 219, 223, 124,
210, 184, 142, 239, 201, 25, 186, 51, 6, 50, 40, 207, 201, 206, 120, 137, 205, 153,
251, 176, 252, 2, 32, 221, 56, 129, 209, 217, ...>>"}}
```

This is due to [`Inspect.Opts`](https://hexdocs.pm/elixir/Inspect.Opts.html) defaulting its inspection to first 50 items:

> `:limit` - limits the number of items that are inspected for tuples, bitstrings, maps, lists and any other collection of items. It does not apply to printable strings nor printable charlists and defaults to 50. If you don't want to limit the number of items to a particular number, use `:infinity`.

This limit means that we're losing some visibility into the logs and only knowing that it's an encoding error, which is not ideal for production logging.

This PR addresses the issue by updating the encoding error to also log the original content.

The encoding error log after this PR would look like this:

```text
{:error, %Jason.EncodeError{message: \"invalid byte 0xFF in <<255>>\"}, %{domain: [:elixir], 
erlang_pid: #PID<0.289.0>, file: \"/Users/some/dir/ink/test/ink_test.exs\", function: \"test respects log_encoding_error: true/1\", gl: #PID<0.63.0>, 
hostname: \"Deep-Thought\", level: 30, line: 143, mfa: {InkTest, :\"test respects log_encoding_error: true\", 1},
module: InkTest, msg: <<255>>, name: \"ink\", pid: 67721,
time: \"2020-06-09T17:47:03.163Z\", v: 0}}
```