### PR TITLE
"blacklist" mode for metadata config option

### DIFF
--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -26,7 +26,7 @@ defmodule Ink do
   - `:filtered_uri_credentials` URIs that contain credentials for filtering
   (default: `[]`)
   - `:metadata` the metadata keys that should be included in the logs (default:
-  all)
+  all). Supports `{:exclude, [<keys>]}` notation.
   - `:exclude_hostname` exclude local `hostname` from the log (default:
   false)
   - `:log_encoding_error` whether to log errors that happen during JSON encoding
@@ -138,6 +138,10 @@ defmodule Ink do
   end
 
   defp filter_metadata(metadata, %{metadata: nil}), do: metadata
+
+  defp filter_metadata(metadata, %{metadata: {:exclude, blacklist}}) do
+    metadata |> Enum.reject(fn {key, _} -> key in blacklist end)
+  end
 
   defp filter_metadata(metadata, config) do
     metadata |> Enum.filter(fn {key, _} -> key in config.metadata end)

--- a/test/ink_test.exs
+++ b/test/ink_test.exs
@@ -79,6 +79,17 @@ defmodule InkTest do
     assert 1 == decoded_msg["included"]
   end
 
+  test "it excludes blacklisted metadata keys" do
+    Logger.configure_backend(Ink, metadata: {:exclude, [:blacklisted]})
+    Logger.metadata(blacklisted: 1, included: 1)
+    Logger.info("test")
+
+    assert_receive {:io_request, _, _, {:put_chars, :unicode, msg}}
+    decoded_msg = Jason.decode!(msg)
+    assert nil == decoded_msg["blacklisted"]
+    assert 1 == decoded_msg["included"]
+  end
+
   test "it puts the erlang process pid into erlang_pid" do
     Logger.info("test")
 


### PR DESCRIPTION
Hi,

**Problem**
We're using Ink and Sentry in the same codebase. It appeared that [Sentry](https://docs.sentry.io/platforms/elixir/) has recently switched to using logger metadata to store its context. We’ve upgraded our sentry dependency - and now we get `:sentry` metadata key in all our logs in Datadog, with a really massive payload.

**Solution**
This PR introduce a “blacklist” mode for Ink’s `:metadata` config option:

      config :logger, Ink,
        metadata: {:exclude, [:sentry]}
 
I'm still in doubt if `{:exclude, ...}` notation is better than a separate `exclude_metadata` configuration parameter. At least it resolves questions like "what if both whitelist- and blacklist-mode options provided".
