### PR TITLE
Draft: support for all log level, hide metadata and monolog log levels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ ink-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+
+# Ignore IntelliJ files
+/.idea/
+/*.iml

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Just add `:ink` to your dependencies and run `mix deps.get`.
 ```elixir
 def deps do
   [
-    {:ink, "~> 1.0"}
+    {:ink, "~> 1.3"}
   ]
 end
 ```

--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -122,7 +122,7 @@ defmodule Ink do
 
   def handle_event({_, _, {Logger, message, timestamp, metadata}}, state) do
     # Not sure why or where the log level from Logger gets changed, but in order
-    # to get the origial log level I use the erlang one.
+    # to get the original log level I use the erlang one.
     level = Keyword.get(metadata, :erl_level, :debug)
 
     log_message(message, level, timestamp, metadata, state)

--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -120,7 +120,7 @@ defmodule Ink do
     {:ok, state}
   end
 
-  def handle_event({_, _, {Logger, message, timestamp, metadata}} = xxx, state) do
+  def handle_event({_, _, {Logger, message, timestamp, metadata}}, state) do
     # Not sure why or where the log level from Logger gets changed, but in order
     # to get the origial log level I use the erlang one.
     level = Keyword.get(metadata, :erl_level, :debug)

--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -167,9 +167,9 @@ defmodule Ink do
 
   defp process_metadata(metadata, config) do
     metadata
+    |> rename_metadata_fields
     |> filter_metadata(config)
     |> hide_metadata(config)
-    |> rename_metadata_fields
     |> Enum.into(%{})
     |> Map.delete(:time)
   end

--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -126,10 +126,11 @@ defmodule Ink do
     {:ok, state}
   end
 
-  def handle_event({_, _, {Logger, message, timestamp, metadata}}, state) do
+  def handle_event({level, _, {Logger, message, timestamp, metadata}}, state) do
     # Not sure why or where the log level from Logger gets changed, but in order
-    # to get the original log level I use the erlang one.
-    level = Keyword.get(metadata, :erl_level, :debug)
+    # to get the original log level I use the erlang one and use the Logger one
+    # only as fallback.
+    level = Keyword.get(metadata, :erl_level, level)
 
     log_message(message, level, timestamp, metadata, state)
 

--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -73,6 +73,12 @@ defmodule Ink do
       config :logger, Ink,
         metadata: [:pid, :my_field]
 
+  Alternatively, if you only want to suppress specific metadata, but include
+  anything else in your log, you need to configure the hidden fields.
+
+      config :logger, Ink,
+        hide_metadata: [:gl, :erl_level]
+
   *Note*: Since the term PID is also prevalent in the UNIX world, services like
    LogStash expect an integer if they encounter a field named `pid`. Therefore,
    `Ink` will log the PID as `erlang_pid`.

--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -271,6 +271,20 @@ defmodule Ink do
     end
   end
 
+  # https://github.com/Seldaek/monolog/blob/main/doc/01-usage.md#log-levels
+  defp level(level, :monolog) do
+    case level do
+      :debug -> 100
+      :info -> 200
+      :notice -> 250
+      :warning -> 300
+      :error -> 400
+      :critical -> 500
+      :alert -> 550
+      :emergency -> 600
+    end
+  end
+
   defp hostname do
     with {:ok, hostname} <- :inet.gethostname(), do: List.to_string(hostname)
   end

--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -76,6 +76,30 @@ defmodule Ink do
   *Note*: Since the term PID is also prevalent in the UNIX world, services like
    LogStash expect an integer if they encounter a field named `pid`. Therefore,
    `Ink` will log the PID as `erlang_pid`.
+
+  ### Status Mapping
+
+  `Ink` currently supports three different mapping for the log levels.
+
+  By default the `:bunyan` mapper is used. As Bunyan does not distinguish
+  between `:info` and `:notice`, as well as between `:error`, `:critical`
+  and `:alert`, `:info` and `:notice` are both handled as `:info`, and
+  `:error`, `:critical` and `:alert` are all handled as `:error`. For
+  more information on Bunyan's log levels look at
+  https://github.com/trentm/node-bunyan#levels
+
+  The second mapper is `:rfc5424`, which is returning the log levels in
+  accordance to the Syslog protocol. For more information look at the
+  documentation over on
+  http://erlang.org/documentation/doc-10.0/lib/kernel-6.0/doc/html/logger_chapter.html#log-level
+
+  Last but not least you can use the `:monolog` mapper. These log leves
+  are based on the Syslog protocol as well, but use a different value
+  as representation for the corresponding level. The biggest difference
+  is that while the Syslog protocol log level value get lower while
+  their significance raises, Monolog's log level values increase in
+  value while the significance raises. For more information see
+  https://github.com/Seldaek/monolog/blob/main/doc/01-usage.md#log-levels
   """
 
   @behaviour :gen_event
@@ -97,8 +121,8 @@ defmodule Ink do
   end
 
   def handle_event({_, _, {Logger, message, timestamp, metadata}} = xxx, state) do
-    # Not sure why or where the log level from Logger gets changed, but in order to get the origial log level
-    # I use the erlang one
+    # Not sure why or where the log level from Logger gets changed, but in order
+    # to get the origial log level I use the erlang one.
     level = Keyword.get(metadata, :erl_level, :debug)
 
     log_message(message, level, timestamp, metadata, state)

--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -96,7 +96,11 @@ defmodule Ink do
     {:ok, state}
   end
 
-  def handle_event({level, _, {Logger, message, timestamp, metadata}}, state) do
+  def handle_event({_, _, {Logger, message, timestamp, metadata}} = xxx, state) do
+    # Not sure why or where the log level from Logger gets changed, but in order to get the origial log level
+    # I use the erlang one
+    level = Keyword.get(metadata, :erl_level, :debug)
+
     log_message(message, level, timestamp, metadata, state)
     {:ok, state}
   end
@@ -243,8 +247,12 @@ defmodule Ink do
     case level do
       :debug -> 20
       :info -> 30
-      :warn -> 40
+      :notice -> 30
+      :warning -> 40
       :error -> 50
+      :critical -> 50
+      :alert -> 50
+      :emergency -> 60
     end
   end
 
@@ -253,8 +261,12 @@ defmodule Ink do
     case level do
       :debug -> 7
       :info -> 6
-      :warn -> 4
+      :notice -> 5
+      :warning -> 4
       :error -> 3
+      :critical -> 2
+      :alert -> 1
+      :emergency -> 0
     end
   end
 

--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -175,6 +175,7 @@ defmodule Ink do
   end
 
   defp filter_metadata(metadata, %{metadata: nil}), do: metadata
+  defp filter_metadata(metadata, %{metadata: :all}), do: metadata
 
   defp filter_metadata(metadata, config) do
     metadata |> Enum.filter(fn {key, _} -> key in config.metadata end)

--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -102,6 +102,7 @@ defmodule Ink do
     level = Keyword.get(metadata, :erl_level, :debug)
 
     log_message(message, level, timestamp, metadata, state)
+
     {:ok, state}
   end
 

--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -161,6 +161,7 @@ defmodule Ink do
   defp process_metadata(metadata, config) do
     metadata
     |> filter_metadata(config)
+    |> hide_metadata(config)
     |> rename_metadata_fields
     |> Enum.into(%{})
     |> Map.delete(:time)
@@ -170,6 +171,12 @@ defmodule Ink do
 
   defp filter_metadata(metadata, config) do
     metadata |> Enum.filter(fn {key, _} -> key in config.metadata end)
+  end
+
+  defp hide_metadata(metadata, %{hide_metadata: nil}), do: metadata
+
+  defp hide_metadata(metadata, config) do
+    metadata |> Enum.filter(fn {key, _} -> key not in config.hide_metadata end)
   end
 
   defp rename_metadata_fields(metadata) do
@@ -262,6 +269,7 @@ defmodule Ink do
       secret_strings: [],
       io_device: :stdio,
       metadata: nil,
+      hide_metadata: nil,
       exclude_hostname: false,
       log_encoding_error: true
     }

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ink.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/ivx/ink"
-  @version "1.3.0"
+  @version "1.3.1-beta"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ink.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/ivx/ink"
-  @version "1.3.1-beta"
+  @version "1.3.2-beta"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ink.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/ivx/ink"
-  @version "1.3.2-beta"
+  @version "1.3.0-beta2"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ink.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/ivx/ink"
-  @version "1.2.0"
+  @version "1.3.0"
 
   def project do
     [

--- a/test/ink_test.exs
+++ b/test/ink_test.exs
@@ -146,6 +146,31 @@ defmodule InkTest do
     end
   end
 
+  @levels [
+    debug: 100,
+    info: 200,
+    notice: 250,
+    warning: 300,
+    error: 400,
+    critical: 500,
+    alert: 550,
+    emergency: 600,
+  ]
+
+  for {fun, level} <- @levels do
+    test "it respects status_mapping: :monolog (#{fun})" do
+      Logger.configure_backend(Ink, status_mapping: :monolog)
+
+      str = unquote(to_string(fun))
+
+      Logger.unquote(fun)(str)
+
+      assert_receive {:io_request, _, _, {:put_chars, :unicode, msg}}
+      assert msg |> Jason.decode!() |> Map.fetch!("msg") == str
+      assert msg |> Jason.decode!() |> Map.fetch!("level") == unquote(level)
+    end
+  end
+
   test "it filters preconfigured secret strings" do
     Logger.info("this is moep")
 

--- a/test/ink_test.exs
+++ b/test/ink_test.exs
@@ -79,6 +79,17 @@ defmodule InkTest do
     assert 1 == decoded_msg["included"]
   end
 
+  test "it excludes configured excluded metadata" do
+    Logger.configure_backend(Ink, hide_metadata: [:excluded])
+    Logger.metadata(not_excluded: 1, excluded: 1)
+    Logger.info("test")
+
+    assert_receive {:io_request, _, _, {:put_chars, :unicode, msg}}
+    decoded_msg = Jason.decode!(msg)
+    assert 1 == decoded_msg["not_excluded"]
+    assert nil == decoded_msg["excluded"]
+  end
+
   test "it puts the erlang process pid into erlang_pid" do
     Logger.info("test")
 

--- a/test/ink_test.exs
+++ b/test/ink_test.exs
@@ -68,6 +68,20 @@ defmodule InkTest do
              decoded_msg["function"]
   end
 
+  test "it logs all metadata if configured to :all" do
+    Logger.configure_backend(Ink, metadata: :all)
+    Logger.metadata(not_included: 1, included: 1)
+    Logger.info("test")
+
+    assert_receive {:io_request, _, _, {:put_chars, :unicode, msg}}
+    decoded_msg = Jason.decode!(msg)
+    assert 1 == decoded_msg["not_included"]
+    assert 1 == decoded_msg["included"]
+
+    assert "test it logs all metadata if configured to :all/1" ==
+             decoded_msg["function"]
+  end
+
   test "it only includes configured metadata" do
     Logger.configure_backend(Ink, metadata: [:included])
     Logger.metadata(not_included: 1, included: 1)

--- a/test/ink_test.exs
+++ b/test/ink_test.exs
@@ -7,12 +7,10 @@ defmodule InkTest do
     {:ok, _} = Logger.add_backend(Ink)
     Logger.configure_backend(Ink, io_device: self())
 
-    on_exit(
-      fn ->
-        Logger.flush()
-        Logger.remove_backend(Ink)
-      end
-    )
+    on_exit(fn ->
+      Logger.flush()
+      Logger.remove_backend(Ink)
+    end)
   end
 
   test "it can be configured" do
@@ -212,9 +210,7 @@ defmodule InkTest do
     Logger.info("test")
 
     assert_receive {:io_request, _, _, {:put_chars, :unicode, msg}}
-    assert msg
-           |> Jason.decode!()
-           |> Map.get("hostname", :excluded) == :excluded
+    assert msg |> Jason.decode!() |> Map.get("hostname", :excluded) == :excluded
   end
 
   test "respects log_encoding_error: true" do
@@ -225,7 +221,7 @@ defmodule InkTest do
 
     assert msg =~
              "{:error, %Jason.EncodeError{" <>
-             "message: \"invalid byte 0xFF in <<255>>\"}}"
+               "message: \"invalid byte 0xFF in <<255>>\"}}"
   end
 
   test "respects log_encoding_error: false" do

--- a/test/ink_test.exs
+++ b/test/ink_test.exs
@@ -7,10 +7,12 @@ defmodule InkTest do
     {:ok, _} = Logger.add_backend(Ink)
     Logger.configure_backend(Ink, io_device: self())
 
-    on_exit(fn ->
-      Logger.flush()
-      Logger.remove_backend(Ink)
-    end)
+    on_exit(
+      fn ->
+        Logger.flush()
+        Logger.remove_backend(Ink)
+      end
+    )
   end
 
   test "it can be configured" do
@@ -185,7 +187,9 @@ defmodule InkTest do
     Logger.info("test")
 
     assert_receive {:io_request, _, _, {:put_chars, :unicode, msg}}
-    assert msg |> Jason.decode!() |> Map.get("hostname", :excluded) == :excluded
+    assert msg
+           |> Jason.decode!()
+           |> Map.get("hostname", :excluded) == :excluded
   end
 
   test "respects log_encoding_error: true" do
@@ -196,7 +200,7 @@ defmodule InkTest do
 
     assert msg =~
              "{:error, %Jason.EncodeError{" <>
-               "message: \"invalid byte 0xFF in <<255>>\"}}"
+             "message: \"invalid byte 0xFF in <<255>>\"}}"
   end
 
   test "respects log_encoding_error: false" do

--- a/test/ink_test.exs
+++ b/test/ink_test.exs
@@ -79,7 +79,7 @@ defmodule InkTest do
     assert 1 == decoded_msg["included"]
   end
 
-  test "it excludes configured excluded metadata" do
+  test "it excludes configured hidden metadata" do
     Logger.configure_backend(Ink, hide_metadata: [:excluded])
     Logger.metadata(not_excluded: 1, excluded: 1)
     Logger.info("test")


### PR DESCRIPTION
I added support for all log levels, including `:emergency` to all mappers. I also added a new monolog mapper for Monolog's log levels. Last but not least I added a new configuration option called `:hide_metadata` to enable suppression of specific metadata, so that you can log all metadata except the hidden ones. 