### PR TITLE
Removed deprecated calls to `System.get_pid/0`

### DIFF
--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -170,7 +170,7 @@ defmodule Ink do
        when is_binary(message) do
     %{
       name: name(),
-      pid: System.get_pid() |> String.to_integer(),
+      pid: System.pid() |> String.to_integer(),
       msg: message,
       time: formatted_timestamp(timestamp),
       level: level(level, config.status_mapping),
@@ -181,7 +181,7 @@ defmodule Ink do
   defp base_map(message, timestamp, level, config) when is_binary(message) do
     %{
       name: name(),
-      pid: System.get_pid() |> String.to_integer(),
+      pid: System.pid() |> String.to_integer(),
       hostname: hostname(),
       msg: message,
       time: formatted_timestamp(timestamp),


### PR DESCRIPTION
Using new Elixir versions (at least using 1.13.3), we get the following warning:

```
warning: System.get_pid/0 is deprecated. Use System.pid/0 instead
Invalid call found at 2 locations:
  lib/ink.ex:173: Ink.base_map/4
  lib/ink.ex:184: Ink.base_map/4
```

These simple changes eliminate the warnings.