### PR TITLE
Allow configure status_mapping to convert the level to string

### DIFF
--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -258,6 +258,10 @@ defmodule Ink do
     end
   end
 
+  defp level(level, :string) do
+    Atom.to_string(level)
+  end
+
   defp hostname do
     with {:ok, hostname} <- :inet.gethostname(), do: List.to_string(hostname)
   end

--- a/test/ink_test.exs
+++ b/test/ink_test.exs
@@ -102,6 +102,14 @@ defmodule InkTest do
     assert msg |> Jason.decode!() |> Map.fetch!("level") == 30
   end
 
+  test "it respects status_mapping: :string" do
+    Logger.configure_backend(Ink, status_mapping: :string)
+    Logger.info("test")
+
+    assert_receive {:io_request, _, _, {:put_chars, :unicode, msg}}
+    assert msg |> Jason.decode!() |> Map.fetch!("level") == "info"
+  end
+
   test "it respects status_mapping: :rfc5424" do
     Logger.configure_backend(Ink, status_mapping: :rfc5424)
     Logger.info("test")


### PR DESCRIPTION
Grafana Loki will use the `level` string to choose the color used on the line to
identify if is everything ok or wrong.
